### PR TITLE
CASM-4667 Migrate to build-sign-scan@v2 with new signing key

### DIFF
--- a/.github/workflows/iuf-container.yaml
+++ b/.github/workflows/iuf-container.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,25 +32,24 @@ jobs:
       contents: read
       id-token: write
     env:
-      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/iuf
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/iuf
       DOCKER_TAG: v0.1.12
     steps:
       - name: build-sign-scan
-        uses: Cray-HPE/github-actions/build-sign-scan@main
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
         with:
-          # Only push on main builds
-          docker_push: ${{ github.ref == 'refs/heads/main' }}
           context_path: "."
           docker_repo: ${{ env.DOCKER_REPO }}
           docker_tag: ${{ env.DOCKER_TAG }}
           docker_secrets: |
             SLES_REPO_USERNAME=${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
             SLES_REPO_PASSWORD=${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
-          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
-          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT }}
-          cosign_key: ${{ secrets.COSIGN_KEY }}
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
-          github_sha: $GITHUB_SHA
           fail_on_snyk_errors: true
           snyk_exclude_app_vulns: true


### PR DESCRIPTION
## Summary and Scope

* Migrate to a rolling tag `build-sign-scan/v2` of `Cray-HPE/github-actions/build-sign-scan` action, instead of using `main`.
* Migrate to new signing infrastructure and key as mandated by [CASM-4667](https://jira-pro.it.hpe.com:8443/browse/CASM-4667).

## Issues and Related PRs

* Needed for [CASM-4667](https://jira-pro.it.hpe.com:8443/browse/CASM-4667)

## Testing
### Tested on:

* Github workflow
* Local development environment

### Test description:

Successfully built image, verified that from non-main branch image is not signed and pushed to `unstable`: https://github.com/Cray-HPE/iuf-containers/actions/runs/8914422319

## Risks and Mitigations

Low - we are not using image signatures yet
