### PR TITLE
Change Stable image build strategy from 'refs/heads/main' to 'tag'

### DIFF
--- a/.github/workflows/iuf-container.yaml
+++ b/.github/workflows/iuf-container.yaml
@@ -32,7 +32,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/iuf
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref_type == 'tag' && 'stable' || 'unstable' }}/iuf
       DOCKER_TAG: v0.1.13
     steps:
       - name: build-sign-scan


### PR DESCRIPTION
## Summary and Scope

Changing  Stable image build strategy from 'refs/heads/main' to 'tag'

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._


* Resolves [CASMPET-7293](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7293)


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

